### PR TITLE
'Call' bytecode instead of 'absjump'

### DIFF
--- a/common/base.mini.fth
+++ b/common/base.mini.fth
@@ -9,7 +9,7 @@ word ;         define ] ['] exit c, latest @ hide [ ' [ c, ' exit c, immediate
 : exit, ['] exit c, ;
 : br,   ['] branch  c, ;
 : ?br,  ['] branch0 c, ;
-: jump, ['] tailcall c, ;
+: jump, ['] jump c, ;
 : call, ['] call c, ;
 : lit,  ['] lit  c, ;
 : litc, ['] litc c, ;
@@ -98,7 +98,7 @@ word ;         define ] ['] exit c, latest @ hide [ ' [ c, ' exit c, immediate
 
 : >body  6 + ;
 : >does  >body 3 - ;
-: does!  last >does ['] tailcall swap c!+ cell! ;
+: does!  last >does ['] jump swap c!+ cell! ;
 : create word define something, return, this! ;
 : does>  something, ['] does! xt-call, exit, this! ; immediate
 
@@ -108,9 +108,9 @@ word ;         define ] ['] exit c, latest @ hide [ ' [ c, ' exit c, immediate
 : flag     dup constant 1 lshift ;
 : variable create cell allot ;
 
-: idxer    create , does> @ + ;
-: +field   over idxer + ;
-: field    swap aligned swap +field ;
+: idxer  create , does> @ + ;
+: +field over idxer + ;
+: field  swap aligned swap +field ;
 
 \ ===
 
@@ -128,6 +128,7 @@ word ;         define ] ['] exit c, latest @ hide [ ' [ c, ' exit c, immediate
 \ you can define different string routines
 \ then set them to a callback
 \ then string, calls them
+\ TODO look into ASSIGN from polyforth
 : header, something, something, somewhere, rot this! ;
 : s"      header, swap here @ string, dist swap ! this! ; immediate
 
@@ -152,6 +153,8 @@ thisthing
 :dyn can-redefine 4 5 6 ##.s drop drop drop ;
 
 thisthing
+
+' thisthing execute
 
 ##.s
 

--- a/common/base.mini.fth
+++ b/common/base.mini.fth
@@ -1,3 +1,5 @@
+here @
+
 word ##.s      define ' ext c, 0 c, 0 c, ' exit c,
 word flipb!    define ] tuck c@ xor swap c! [ ' exit c,
 word flipt!    define ] 0x80 swap rshift swap >terminator flipb! [ ' exit c,
@@ -16,10 +18,10 @@ word ;         define ] ['] exit c, latest @ hide [ ' [ c, ' exit c, immediate
 
 : blank,     0 c, 0 c, ;
 : blankc,    0 c, ;
-: later,     here @ blank, ;
-: laterc,    here @ blankc, ;
-: something, lit, later, ;
-: somewhere, jump, later, ;
+: (later),   here @ blank, ;
+: (later)c,  here @ blankc, ;
+: something, lit, (later), ;
+: somewhere, jump, (later), ;
 : return,    exit, blankc, ;
 
 : c!+ tuck c! 1+ ;
@@ -42,14 +44,14 @@ word ;         define ] ['] exit c, latest @ hide [ ' [ c, ' exit c, immediate
 : br-mark!   dup how-far swap c! ;
 : back,      how-far negate c, ;
 
-: if   ?br, laterc, ; immediate
-: else br,  laterc, swap br-mark! ; immediate
+: if   ?br, (later)c, ; immediate
+: else br,  (later)c, swap br-mark! ; immediate
 : then br-mark! ; immediate
 
 : begin here @ ; immediate
 : until ?br, back, ; immediate
 : again br,  back, ; immediate
-: while ?br, laterc, ; immediate
+: while ?br, (later)c, ; immediate
 : repeat swap br, back, br-mark! ; immediate
 
 : char   word drop c@ ;
@@ -132,6 +134,11 @@ word ;         define ] ['] exit c, latest @ hide [ ' [ c, ' exit c, immediate
 : header, something, something, somewhere, rot this! ;
 : s"      header, swap here @ string, how-far swap ! jump-mark! ; immediate
 
+how-far ##.s
+
+
+
+
 0 cell field >one
   cell field >two
 constant size
@@ -143,11 +150,26 @@ size
 ##.s
 
 : ext, ['] ext c, cell,l ;
-: ##.s    [ 0x0001 ext, ] ;
+: ##.s    [ 0x0000 ext, ] ;
 : ##break [ 0x0001 ext, ] ;
 : ##type  [ 0x0002 ext, ] ;
 : ##cr    [ 0x0003 ext, ] ;
 : ##mem   [ 0x0004 ext, ] ;
+##.s
+
+: next, here @ 2 + xt, ;
+: :dyn word define jump, next, latest @ hide ] ;
+: setdyn ' 1+ xt! ;
+
+:dyn frame 1 2 3 ##.s drop drop drop ;
+
+frame
+
+:noname 4 5 6 ##.s drop drop drop ;
+setdyn frame
+
+frame
+
 
 word hello ##type ##cr
 ##mem

--- a/zig/src/bytecodes.zig
+++ b/zig/src/bytecodes.zig
@@ -358,12 +358,13 @@ fn branch0(mini: *vm.MiniVM, ctx: vm.ExecutionContext) vm.Error!void {
 }
 
 fn find(mini: *vm.MiniVM, _: vm.ExecutionContext) vm.Error!void {
-    const word = try mini.popSlice();
+    const len, const addr = try mini.data_stack.popMultiple(2);
+    const word = try vm.mem.sliceFromAddrAndLen(mini.memory, addr, len);
     const result_or_error = mini.lookupStringAndGetAddress(word);
     const result = result_or_error catch |err| switch (err) {
         error.WordNotFound => {
-            try mini.data_stack.push(0);
-            try mini.data_stack.push(0);
+            try mini.data_stack.push(addr);
+            try mini.data_stack.push(len);
             try mini.data_stack.push(vm.fromBool(vm.Cell, false));
             return;
         },
@@ -404,6 +405,7 @@ fn define(mini: *vm.MiniVM, _: vm.ExecutionContext) vm.Error!void {
 // this only works for forth words
 // TODO
 // should a version of this be made that works for bytecodes?
+// TODO this doesnt work from the interpreter, you have to explicitly run an exec loop
 fn execute(mini: *vm.MiniVM, _: vm.ExecutionContext) vm.Error!void {
     const addr = try mini.data_stack.pop();
     try mini.absoluteJump(addr, true);

--- a/zig/src/bytecodes.zig
+++ b/zig/src/bytecodes.zig
@@ -22,10 +22,11 @@ const abs_jump_definition = BytecodeDefinition{
     .executeSemantics = executeAbsJump,
 };
 
-fn executeAbsJump(mini: *vm.MiniVM, ctx: vm.ExecutionContext) vm.Error!void {
-    const high = ctx.current_bytecode & 0x7f;
-    const low = try mini.readByteAndAdvancePC();
-    const addr = @as(vm.Cell, high) << 8 | low;
+fn executeAbsJump(mini: *vm.MiniVM, _: vm.ExecutionContext) vm.Error!void {
+    // const high = ctx.current_bytecode & 0x7f;
+    // const low = try mini.readByteAndAdvancePC();
+    // const addr = @as(vm.Cell, high) << 8 | low;
+    const addr = try mini.readCellAndAdvancePC();
     try mini.absoluteJump(addr, true);
 }
 
@@ -208,7 +209,8 @@ const lookup_table = [128]BytecodeDefinition{
     constructBasicBytecode("cmove>", cmoveUp),
     constructBasicBytecode("mem=", memEq),
 
-    .{},
+    constructTagBytecode("call", executeAbsJump),
+
     .{},
     .{},
     .{},
@@ -412,10 +414,10 @@ fn execute(mini: *vm.MiniVM, _: vm.ExecutionContext) vm.Error!void {
 ///   pushing anything to the return stack
 fn tailcall(mini: *vm.MiniVM, _: vm.ExecutionContext) vm.Error!void {
     const addr = try mini.readCellAndAdvancePC();
-    const swapped_addr = @byteSwap(addr);
+    // const swapped_addr = @byteSwap(addr);
     // TODO this mask should be a constant somewhere
-    const masked_addr = swapped_addr & 0x7fff;
-    try mini.absoluteJump(masked_addr, false);
+    // const masked_addr = swapped_addr & 0x7fff;
+    try mini.absoluteJump(addr, false);
 }
 
 fn store(mini: *vm.MiniVM, _: vm.ExecutionContext) vm.Error!void {

--- a/zig/src/bytecodes.zig
+++ b/zig/src/bytecodes.zig
@@ -321,7 +321,6 @@ fn define(mini: *vm.MiniVM, _: vm.ExecutionContext) vm.Error!void {
 // this only works for forth words
 // TODO
 // should a version of this be made that works for bytecodes?
-// TODO this doesnt work from the interpreter, you have to explicitly run an exec loop
 fn executeExecute(mini: *vm.MiniVM, _: vm.ExecutionContext) vm.Error!void {
     const addr = try mini.data_stack.pop();
     try mini.absoluteJump(addr, true);

--- a/zig/src/dictionary.zig
+++ b/zig/src/dictionary.zig
@@ -209,32 +209,6 @@ pub fn Dictionary(
             try self.here.commaByteAlignedCell(self.memory, addr);
         }
 
-        //         pub fn compileAbsJump(self: *@This(), addr: vm.Cell) vm.Error!void {
-        //             if (addr > std.math.maxInt(u15)) {
-        //                 return error.InvalidAddress;
-        //             }
-        //
-        //             const base = @as(vm.Cell, bytecodes.base_abs_jump_bytecode) << 8;
-        //             const jump = base | addr;
-        //             try self.here.commaC(self.memory, @truncate(jump >> 8));
-        //             try self.here.commaC(self.memory, @truncate(jump));
-        //         }
-
-        // TODO this is out of date but might be a nice helper function for the vm
-        //         pub fn compileData(self: *@This(), data: []u8) vm.Error!void {
-        //             if (data.len > std.math.maxInt(u12)) {
-        //                 return error.InvalidAddress;
-        //             }
-        //
-        //             const base = @as(vm.Cell, bytecodes.base_data_bytecode) << 8;
-        //             const data_len = base | @as(vm.Cell, @truncate(data.len & 0x0fff));
-        //             try self.here.commaC(self.memory, @truncate(data_len >> 8));
-        //             try self.here.commaC(self.memory, @truncate(data_len));
-        //             for (data) |byte| {
-        //                 try self.here.commaC(self.memory, byte);
-        //             }
-        //         }
-
         pub fn compileConstant(
             self: *@This(),
             name: []const u8,

--- a/zig/src/dictionary.zig
+++ b/zig/src/dictionary.zig
@@ -202,17 +202,21 @@ pub fn Dictionary(
             try self.here.commaC(self.memory, value);
         }
 
-        // TODO write tests for these
         pub fn compileAbsJump(self: *@This(), addr: vm.Cell) vm.Error!void {
-            if (addr > std.math.maxInt(u15)) {
-                return error.InvalidAddress;
-            }
-
-            const base = @as(vm.Cell, bytecodes.base_abs_jump_bytecode) << 8;
-            const jump = base | addr;
-            try self.here.commaC(self.memory, @truncate(jump >> 8));
-            try self.here.commaC(self.memory, @truncate(jump));
+            try self.here.commaC(self.memory, bytecodes.lookupBytecodeByName("call") orelse unreachable);
+            try self.here.commaByteAlignedCell(self.memory, addr);
         }
+
+        //         pub fn compileAbsJump(self: *@This(), addr: vm.Cell) vm.Error!void {
+        //             if (addr > std.math.maxInt(u15)) {
+        //                 return error.InvalidAddress;
+        //             }
+        //
+        //             const base = @as(vm.Cell, bytecodes.base_abs_jump_bytecode) << 8;
+        //             const jump = base | addr;
+        //             try self.here.commaC(self.memory, @truncate(jump >> 8));
+        //             try self.here.commaC(self.memory, @truncate(jump));
+        //         }
 
         // TODO this is out of date but might be a nice helper function for the vm
         //         pub fn compileData(self: *@This(), data: []u8) vm.Error!void {

--- a/zig/src/dictionary.zig
+++ b/zig/src/dictionary.zig
@@ -117,6 +117,8 @@ pub fn Dictionary(
                     const terminator = TerminatorInfo.fromByte(terminator_byte);
                     if (!terminator.is_hidden) {
                         return latest;
+                    } else {
+                        // TODO print warning when you find a hidden word :)
                     }
                 }
                 latest = (try vm.mem.cellAt(self.memory, latest)).*;

--- a/zig/src/mini.zig
+++ b/zig/src/mini.zig
@@ -406,8 +406,7 @@ pub const MiniVM = struct {
         }
     }
 
-    fn executeMiniWord(self: *@This(), addr: Cell) Error!void {
-        const cfa_addr = try self.dictionary.toCfa(addr);
+    pub fn executeCfa(self: *@This(), cfa_addr: Cell) Error!void {
         // NOTE
         // this puts some 'dummy data' on the return stack
         // the 'dummy data' is actually the xt currently being executed
@@ -421,7 +420,13 @@ pub const MiniVM = struct {
         try self.executionLoop();
     }
 
-    fn executionLoop(self: *@This()) Error!void {
+    // TODO can probably refactor this
+    fn executeMiniWord(self: *@This(), addr: Cell) Error!void {
+        const cfa_addr = try self.dictionary.toCfa(addr);
+        try self.executeCfa(cfa_addr);
+    }
+
+    pub fn executionLoop(self: *@This()) Error!void {
         // Execution strategy:
         //   1. increment PC, then
         //   2. evaluate byte at PC-1

--- a/zig/src/mini.zig
+++ b/zig/src/mini.zig
@@ -492,7 +492,7 @@ pub const MiniVM = struct {
         is_bytecode: bool,
         value: Cell,
     } {
-        // NOTE
+        // NOTE TODO
         // in this case lookupString could have a early return to not try and parse numbers
         if (try self.lookupString(str)) |word_info| {
             switch (word_info) {


### PR DESCRIPTION
this PR is to create a new tag bytecode: 'call'
'tailcall' will probably be renamed to 'jump'
absjumps will be three bytes instead of two
this allows us to use 64k of memory, simplifies the compiler and language, frees up 63 bytecodes 
downsides are calls to mini word take up more space, but this isnt a big deal